### PR TITLE
fix(@actions-internal/patch): edit message

### DIFF
--- a/VKUI/patch/src/message.ts
+++ b/VKUI/patch/src/message.ts
@@ -25,7 +25,7 @@ ${patchRefs
   .map((pathRef) => {
     return [
       `git cherry-pick --no-commit ${pathRef}`,
-      "git checkout HEAD --no-commit '**/__image_snapshots__/*.png'",
+      "git checkout HEAD **/__image_snapshots__/*.png",
       'git commit --no-verify --no-edit',
     ].join('\n');
   })

--- a/VKUI/patch/src/message.ts
+++ b/VKUI/patch/src/message.ts
@@ -25,7 +25,7 @@ ${patchRefs
   .map((pathRef) => {
     return [
       `git cherry-pick --no-commit ${pathRef}`,
-      "git checkout HEAD **/__image_snapshots__/*.png",
+      'git checkout HEAD **/__image_snapshots__/*.png',
       'git commit --no-verify --no-edit',
     ].join('\n');
   })


### PR DESCRIPTION
- У `checkout` нет флага `--no-commit`
- glob pattern не должен быть завёрнут в кавычки