### PR TITLE
dependabot: use 'groups'; set schedule to weekly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,13 +15,20 @@ updates:
     allow:
       - dependency-type: 'direct'
     groups:
-      typescript-eslint:
-        patterns:
-          - '@typescript-eslint/*'
       jest:
         patterns:
-          - 'jest'
+          - 'jest*'
           - '@jest/*'
+          - '@swc/jest'
+      eslint:
+        patterns:
+          - 'eslint*'
+          - '@vkontakte/eslint-plugin'
+          - '@typescript-eslint/*'
+      prettier:
+        patterns:
+          - 'prettier'
+          - '@vkontakte/prettier-config'
     reviewers:
       - 'VKCOM/vk-sec'
       - 'VKCOM/vkui-core'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,7 @@ updates:
   - package-ecosystem: 'github-actions'
     directory: '/'
     schedule:
-      interval: 'daily'
+      interval: 'weekly'
     reviewers:
       - 'VKCOM/vk-sec'
       - 'VKCOM/vkui-core'
@@ -11,9 +11,17 @@ updates:
   - package-ecosystem: 'npm'
     directory: '/'
     schedule:
-      interval: 'daily'
+      interval: 'weekly'
     allow:
       - dependency-type: 'direct'
+    groups:
+      typescript-eslint:
+        patterns:
+          - '@typescript-eslint/*'
+      jest:
+        patterns:
+          - 'jest'
+          - '@jest/*'
     reviewers:
       - 'VKCOM/vk-sec'
       - 'VKCOM/vkui-core'


### PR DESCRIPTION
## Ссылки

- [Configuration options for the dependabot.yml file • groups](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#groups)