### PR TITLE
fix(@actions-internal/patch): optimize cherry-pick

### DIFF
--- a/VKUI/patch/src/getMergeData.ts
+++ b/VKUI/patch/src/getMergeData.ts
@@ -1,0 +1,40 @@
+import * as exec from '@actions/exec';
+import * as github from '@actions/github';
+
+const MINIMUM_MERGE_COMMIT_COUNT = 2;
+
+export type MergeMethod = 'merge' | 'squash';
+
+export type MergeData = {
+  method: MergeMethod;
+  mergeCommitSHA: string;
+};
+
+export async function getMergeData(
+  gh: ReturnType<typeof github.getOctokit>,
+  repo: typeof github.context.repo,
+  pullNumber: number,
+): Promise<MergeData> {
+  const pullRequest = await gh.rest.pulls.get({ ...repo, pull_number: pullNumber });
+  const mergeCommitSHA = pullRequest.data.merge_commit_sha || '';
+
+  let method: MergeMethod = 'merge';
+
+  try {
+    await exec.exec('git', ['show', '-s', '--pretty=%p', mergeCommitSHA], {
+      listeners: {
+        stdout: (dataRaw: Buffer) => {
+          const data = dataRaw.toString().trim().split(' ');
+          method = data.length >= MINIMUM_MERGE_COMMIT_COUNT ? 'merge' : 'squash';
+        },
+      },
+    });
+  } catch (e) {
+    console.error(e);
+  }
+
+  return {
+    method,
+    mergeCommitSHA,
+  };
+}

--- a/VKUI/patch/src/main.ts
+++ b/VKUI/patch/src/main.ts
@@ -104,16 +104,13 @@ async function run(): Promise<void> {
         // заведомо всё в порядке.
         await exec.exec('git', ['checkout', 'HEAD', '**/__image_snapshots__/*.png']);
 
-        const GIT_DIFF_EXIT_CODES_DICTIONARY = { NOTHING_TO_COMMIT: 0, FILES_EXIST: 1 };
-        const exitCode = await exec.exec('git', ['diff', '--quiet', 'HEAD'], {
+        const exitDiffCode = await exec.exec('git', ['diff', '--quiet', 'HEAD'], {
           ignoreReturnCode: true,
         });
-
-        switch (exitCode) {
-          case GIT_DIFF_EXIT_CODES_DICTIONARY.NOTHING_TO_COMMIT:
-            continue;
-          case GIT_DIFF_EXIT_CODES_DICTIONARY.FILES_EXIST:
-            await exec.exec('git', ['commit', '--no-verify', '--no-edit']);
+        // eslint-disable-next-line @typescript-eslint/no-magic-numbers
+        const hasCodeToCommit = exitDiffCode !== 0;
+        if (hasCodeToCommit) {
+          await exec.exec('git', ['commit', '--no-verify', '--no-edit']);
         }
       }
     } catch (e) {

--- a/VKUI/patch/src/message.ts
+++ b/VKUI/patch/src/message.ts
@@ -26,7 +26,7 @@ ${patchRefs
     return [
       `git cherry-pick --no-commit ${pathRef}`,
       'git checkout HEAD **/__image_snapshots__/*.png',
-      'git commit --no-verify --no-edit',
+      'git diff --quiet HEAD || git commit --no-verify --no-edit',
     ].join('\n');
   })
   .join('\n\n')}


### PR DESCRIPTION
Используем для черри пика `merge_commit_sha` если PR был смержен методов **squash**. Иначе, черри пикаем по коммитам в PR. При этом исключаем мерж коммит.

Используем `git diff --quiet HEAD`, чтобы обойти кейсы, когда попадается коммит только со скриншотами. Из-за `git checkout HEAD **/__image_snapshots__/*.png'` нечего становится коммитить и Git падает с ошибкой.