### PR TITLE
fix(@actions-internal/patch): fetch with depth=2

### DIFF
--- a/VKUI/patch/src/main.ts
+++ b/VKUI/patch/src/main.ts
@@ -95,7 +95,20 @@ async function run(): Promise<void> {
     }
 
     try {
-      await exec.exec('git', ['fetch', '--no-tags', 'origin', stableBranchRef, ...patchRefs]);
+      if (mergeData.method === 'squash') {
+        await exec.exec('git', ['fetch', '--no-tags', 'origin', stableBranchRef]);
+        await exec.exec('git', [
+          'fetch',
+          '--no-tags',
+          // Перед cherry-pick'ом squash коммита, фетчим этот коммит с флагом `--depth=2`, чтобы
+          // перебить параметр `fetch-depth` у `@actions/checkout`, который по умолчанию равен 1.
+          '--depth=2',
+          'origin',
+          ...patchRefs,
+        ]);
+      } else {
+        await exec.exec('git', ['fetch', '--no-tags', 'origin', stableBranchRef, ...patchRefs]);
+      }
       await exec.exec('git', ['checkout', stableBranchRef]);
 
       for (const patchRef of patchRefs) {


### PR DESCRIPTION
Перед cherry-pick'ом squash коммита, фетчим этот коммит с флагом `--depth=2`, чтобы перебить параметр `fetch-depth` у `@actions/checkout`, который по умолчанию равен 1.

## Почему?

В https://github.com/VKCOM/VKUI/pull/5465 из-за этого упал CI на `patch`. В нём как раз экшен пытался черри-пикнуть сквош коммит https://github.com/VKCOM/VKUI/commit/095c314f27551541f072df4bf5dc168af496948d, но упал из-за мерж конфликта.

`@actions/checkout` инициализирует воркфлоу так:

```sh
git fetch --no-tags --prune --progress --no-recurse-submodules --depth=1 origin +095c314f27551541f072df4bf5dc168af496948d:refs/remotes/origin/master
```

На стороне `@actions-internal/patch` мы дополнительно фетчим стабильную ветку и коммит

```sh
git fetch --no-tags origin 5.6-stable 095c314f27551541f072df4bf5dc168af496948d
```

но это для комита `095c314f27551541f072df4bf5dc168af496948d` фетч будет проигнорирован, т.к. фетч уже был за счёт `@actions/checkout`.

Если сделать `git log` коммита, то видим такой лог:

<img width="320" src="https://github.com/VKCOM/gh-actions/assets/5850354/62d862a6-99a9-4c05-8f04-a5e4efac8581" />

Как видим, в коммите есть нужное изменение из PR https://github.com/VKCOM/VKUI/pull/5465, и вроде всё должно быть ок.

Но черрик-пик

```sh
git cherry-pick --no-commit 095c314f27551541f072df4bf5dc168af496948d
```

приводит к мерж конлфикту.

<details><summary>Лог ошибки</summary>
<p>

```
~/projects/VKUI-core (5.6-stable) $ git cherry-pick --no-commit 095c314f27551541f072df4bf5dc168af496948d
Auto-merging .github/workflows/reusable_workflow_test_e2e.yml
CONFLICT (add/add): Merge conflict in .github/workflows/reusable_workflow_test_e2e.yml
Auto-merging packages/vkui/src/components/Progress/Progress.e2e-playground.tsx
CONFLICT (add/add): Merge conflict in packages/vkui/src/components/Progress/Progress.e2e-playground.tsx
Auto-merging packages/vkui/src/components/Progress/Progress.test.tsx
CONFLICT (add/add): Merge conflict in packages/vkui/src/components/Progress/Progress.test.tsx
Auto-merging packages/vkui/src/components/Progress/Progress.tsx
CONFLICT (add/add): Merge conflict in packages/vkui/src/components/Progress/Progress.tsx
Auto-merging packages/vkui/src/components/Progress/__image_snapshots__/progress-android-chromium-dark-1-snap.png
CONFLICT (add/add): Merge conflict in packages/vkui/src/components/Progress/__image_snapshots__/progress-android-chromium-dark-1-snap.png
Auto-merging packages/vkui/src/components/Progress/__image_snapshots__/progress-android-chromium-light-1-snap.png
CONFLICT (add/add): Merge conflict in packages/vkui/src/components/Progress/__image_snapshots__/progress-android-chromium-light-1-snap.png
Auto-merging packages/vkui/src/components/Progress/__image_snapshots__/progress-ios-webkit-dark-1-snap.png
CONFLICT (add/add): Merge conflict in packages/vkui/src/components/Progress/__image_snapshots__/progress-ios-webkit-dark-1-snap.png
Auto-merging packages/vkui/src/components/Progress/__image_snapshots__/progress-ios-webkit-light-1-snap.png
CONFLICT (add/add): Merge conflict in packages/vkui/src/components/Progress/__image_snapshots__/progress-ios-webkit-light-1-snap.png
Auto-merging packages/vkui/src/components/Progress/__image_snapshots__/progress-vkcom-chromium-dark-1-snap.png
CONFLICT (add/add): Merge conflict in packages/vkui/src/components/Progress/__image_snapshots__/progress-vkcom-chromium-dark-1-snap.png
Auto-merging packages/vkui/src/components/Progress/__image_snapshots__/progress-vkcom-chromium-light-1-snap.png
CONFLICT (add/add): Merge conflict in packages/vkui/src/components/Progress/__image_snapshots__/progress-vkcom-chromium-light-1-snap.png
Auto-merging packages/vkui/src/components/Progress/__image_snapshots__/progress-vkcom-firefox-dark-1-snap.png
CONFLICT (add/add): Merge conflict in packages/vkui/src/components/Progress/__image_snapshots__/progress-vkcom-firefox-dark-1-snap.png
Auto-merging packages/vkui/src/components/Progress/__image_snapshots__/progress-vkcom-firefox-light-1-snap.png
CONFLICT (add/add): Merge conflict in packages/vkui/src/components/Progress/__image_snapshots__/progress-vkcom-firefox-light-1-snap.png
Auto-merging packages/vkui/src/components/Progress/__image_snapshots__/progress-vkcom-webkit-dark-1-snap.png
CONFLICT (add/add): Merge conflict in packages/vkui/src/components/Progress/__image_snapshots__/progress-vkcom-webkit-dark-1-snap.png
Auto-merging packages/vkui/src/components/Progress/__image_snapshots__/progress-vkcom-webkit-light-1-snap.png
CONFLICT (add/add): Merge conflict in packages/vkui/src/components/Progress/__image_snapshots__/progress-vkcom-webkit-light-1-snap.png
Auto-merging packages/vkui/src/components/Snackbar/Snackbar.stories.tsx
CONFLICT (add/add): Merge conflict in packages/vkui/src/components/Snackbar/Snackbar.stories.tsx
Auto-merging packages/vkui/src/components/Snackbar/Snackbar.test.tsx
CONFLICT (add/add): Merge conflict in packages/vkui/src/components/Snackbar/Snackbar.test.tsx
Auto-merging packages/vkui/src/components/Snackbar/Snackbar.tsx
CONFLICT (add/add): Merge conflict in packages/vkui/src/components/Snackbar/Snackbar.tsx
Auto-merging packages/vkui/src/components/Switch/Switch.module.css
CONFLICT (add/add): Merge conflict in packages/vkui/src/components/Switch/Switch.module.css
error: could not apply 095c314f2... fix(Switch): user-select: none; (#5465)
hint: after resolving the conflicts, mark the corrected paths
hint: with 'git add <paths>' or 'git rm <paths>'
Encountered 10 files that should have been pointers, but weren't:
        packages/vkui/src/components/Progress/__image_snapshots__/progress-android-chromium-dark-1-snap.png
        packages/vkui/src/components/Progress/__image_snapshots__/progress-android-chromium-light-1-snap.png
        packages/vkui/src/components/Progress/__image_snapshots__/progress-ios-webkit-dark-1-snap.png
        packages/vkui/src/components/Progress/__image_snapshots__/progress-ios-webkit-light-1-snap.png
        packages/vkui/src/components/Progress/__image_snapshots__/progress-vkcom-chromium-dark-1-snap.png
        packages/vkui/src/components/Progress/__image_snapshots__/progress-vkcom-chromium-light-1-snap.png
        packages/vkui/src/components/Progress/__image_snapshots__/progress-vkcom-firefox-dark-1-snap.png
        packages/vkui/src/components/Progress/__image_snapshots__/progress-vkcom-firefox-light-1-snap.png
        packages/vkui/src/components/Progress/__image_snapshots__/progress-vkcom-webkit-dark-1-snap.png
        packages/vkui/src/components/Progress/__image_snapshots__/progress-vkcom-webkit-light-1-snap.png
```

</p>
</details> 

Черри-пикнулись ещё коммиты:
- [VKCOM/VKUI@`67e3850`](https://togithub.com/VKCOM/VKUI/commit/67e38508d617918448738b397fd3c916a07c84c8).
- [VKCOM/VKUI@`4b6442c`](https://togithub.com/VKCOM/VKUI/commit/4b6442ca4a9a78b4a9ec6f9cfa517d77e73d8fee)
- [VKCOM/VKUI@`1d01c29`](https://togithub.com/VKCOM/VKUI/commit/1d01c29baa84c598d34612e449b6693862c7004d)

Попробовал зафетчить сквош коммит через `--depth=2` и черри-пик начал проходить удачно.

```sh
git fetch --no-tags --depth=2 origin 5.6-stable 095c314f27551541f072df4bf5dc168af496948d
```

Объяснить мне это не получилось. В гугле создать запрос на эту проблему не смог.

Могу ли предположить, что при черри-пике сквош коммита, требуется родительский коммит:

<img width="320" src="https://github.com/VKCOM/gh-actions/assets/5850354/bea9d638-2f25-442e-a812-19529e357722" />

## Нюанс

Возможно решение подходит только для этого кейса. Если что, можно будет использовать `--unshallow` вместо `--depth=2`, чтобы наверняка.

---

- caused by #106