### PR TITLE
Filter out snapshots from squash diff

### DIFF
--- a/VKUI/patch/dist/index.js
+++ b/VKUI/patch/dist/index.js
@@ -14286,7 +14286,6 @@ function run() {
                 core.warning('Необходимо вручную перенести исправление в стабильную ветку');
                 return;
             }
-            // fetch stable branch and patches
             try {
                 if (mergeData.method === 'squash') {
                     yield exec.exec('git', ['fetch', '--no-tags', 'origin', stableBranchRef]);
@@ -14305,10 +14304,18 @@ function run() {
                 }
                 yield exec.exec('git', ['checkout', stableBranchRef]);
                 for (const patchRef of patchRefs) {
-                    yield exec.getExecOutput('bash', [
-                        '-c',
-                        `git --no-pager format-patch ${patchRef} -1 --stdout -- ':!**/__image_snapshots__/*.png' | git am`,
-                    ]);
+                    yield exec.exec('git', ['cherry-pick', '--no-commit', patchRef]);
+                    // Исключаем файлы со скриншотами, т.к. предполагаем, что в стабильной ветке
+                    // заведомо всё в порядке.
+                    yield exec.exec('git', ['checkout', 'HEAD', '**/__image_snapshots__/*.png']);
+                    const exitDiffCode = yield exec.exec('git', ['diff', '--quiet', 'HEAD'], {
+                        ignoreReturnCode: true,
+                    });
+                    // eslint-disable-next-line @typescript-eslint/no-magic-numbers
+                    const hasCodeToCommit = exitDiffCode !== 0;
+                    if (hasCodeToCommit) {
+                        yield exec.exec('git', ['commit', '--no-verify', '--no-edit']);
+                    }
                 }
             }
             catch (e) {

--- a/VKUI/patch/src/main.ts
+++ b/VKUI/patch/src/main.ts
@@ -101,7 +101,7 @@ async function run(): Promise<void> {
         await exec.exec('git', [
           'fetch',
           '--no-tags',
-          // Перед cherry-pick'ом squash коммита, фетчим этот коммит с флагом `--depth=2`, чтобы
+          // Перед переносом диффа коммита, фетчим этот коммит с флагом `--depth=2`, чтобы
           // перебить параметр `fetch-depth` у `@actions/checkout`, который по умолчанию равен 1.
           '--depth=2',
           'origin',
@@ -113,6 +113,9 @@ async function run(): Promise<void> {
 
       await exec.exec('git', ['checkout', stableBranchRef]);
 
+      // Переносим коммиты из PR в стабильную ветку,
+      // исключаем файлы со скриншотами, т.к. предполагаем, что в стабильной ветке
+      // заведомо всё в порядке.
       for (const patchRef of patchRefs) {
         await exec.exec('bash', [
           '-c',

--- a/VKUI/patch/src/main.ts
+++ b/VKUI/patch/src/main.ts
@@ -94,7 +94,7 @@ async function run(): Promise<void> {
       return;
     }
 
-    // fetch stable branch and patches
+    // фетчим стабильную ветку и патчи
     try {
       if (mergeData.method === 'squash') {
         await exec.exec('git', ['fetch', '--no-tags', 'origin', stableBranchRef]);

--- a/VKUI/patch/src/main.ts
+++ b/VKUI/patch/src/main.ts
@@ -114,15 +114,10 @@ async function run(): Promise<void> {
       await exec.exec('git', ['checkout', stableBranchRef]);
 
       for (const patchRef of patchRefs) {
-        const execOutput = await exec.getExecOutput('git', [
-          'format-patch',
-          patchRef,
-          '-1',
-          '--stdout',
-          '--',
-          '":!**/__image_snapshots__/*.png"',
+        await exec.getExecOutput('bash', [
+          '-c',
+          `git --no-pager format-patch ${patchRef} -1 --stdout -- ':!**/__image_snapshots__/*.png' | git am`,
         ]);
-        await exec.exec('git', ['am', execOutput.stdout]);
       }
     } catch (e) {
       console.error(e);

--- a/VKUI/patch/src/main.ts
+++ b/VKUI/patch/src/main.ts
@@ -114,7 +114,7 @@ async function run(): Promise<void> {
       await exec.exec('git', ['checkout', stableBranchRef]);
 
       for (const patchRef of patchRefs) {
-        await exec.getExecOutput('bash', [
+        await exec.exec('bash', [
           '-c',
           `git --no-pager format-patch ${patchRef} -1 --stdout -- ':!**/__image_snapshots__/*.png' | git am`,
         ]);


### PR DESCRIPTION
Use `git format-patch` to prepare the filtered diff on fly and pass it to the `git am`.
This simulate the git `cherry-pick` and allows us to filter out screenshots.

Seems like `git am` doesn't throw an error if the diff is empty we pass to it is empty.

Filtration with `git diff` won't work here as we would loose the commit message.

By default `git format-patch` creates files with diff those can be read by `git am`.
To avoid file creation I use `pipe` to send output of `git format-patch` to `git am`.
Unfortunately `action/exec` can't simulate this `git format-patch ... | git am` with it's interface.
The workaround is to use `/bin/bash -c "comand"`. 

## Tests
Tested on my fork of [VKUI](https://github.com/mendrew/VKUI).

For tests I used:
- commit https://github.com/mendrew/VKUI/commit/ef1cbb441adb144a8ad7158639fc0bd71feb56e4. Here is the action output: https://github.com/mendrew/VKUI/actions/runs/5621997235
- commit https://github.com/mendrew/VKUI/commit/c2a3f809a. Here is the action output: https://github.com/mendrew/VKUI/actions/runs/5622041940

Results are in stable branch: https://github.com/mendrew/VKUI/commits/5.6-stable
- https://github.com/mendrew/VKUI/commit/4ef212459d9f466124c1339e24c19eae3c917b75
- https://github.com/mendrew/VKUI/commit/c75be12526e3c99715ee2c2965d9293c28a53e7c
They don't have files with screenshots from original commits.