### PR TITLE
feat: add shared/download-workflow-artifact

### DIFF
--- a/shared/download-workflow-artifact/action.yml
+++ b/shared/download-workflow-artifact/action.yml
@@ -1,0 +1,69 @@
+name: Download workflow artifact
+description: Download and extract an artifact associated with workflow that trigger workflow_run
+
+inputs:
+  name:
+    description: Name of the artifact to download
+    required: true
+    type: string
+  path:
+    description: Directory with downloaded artifacts
+    required: false
+    type: string
+    default: './'
+
+outputs:
+  found_artifact:
+    value: ${{ steps.artifact.outputs.result }}
+
+runs:
+  using: composite
+  steps:
+    - name: Download artifact
+      id: artifact
+      uses: actions/github-script@v6
+      with:
+        script: |
+          console.log(`downloading artifacts for workflow_run: ${context.payload.workflow_run.id}`);
+          console.log(`workflow_run: ${JSON.stringify(context.payload.workflow_run, null, 2)}`);
+
+          const { data } = await github.rest.actions.listWorkflowRunArtifacts({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            run_id: context.payload.workflow_run.id
+          });
+
+          console.log('total = ', data.total_count);
+
+          const name = '${{ inputs.name }}';
+          const filteredArtifacts = data.artifacts.filter(a => a.name === name);
+
+          if (filteredArtifacts.length === 0) {
+            return 'false';
+          }
+
+          const report = filteredArtifacts[0]
+          const result = await github.rest.actions.downloadArtifact({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            artifact_id: report.id,
+            archive_format: 'zip'
+          });
+
+          if (!result) {
+            return 'false';
+          }
+
+          console.log('download result', result);
+
+          const fs = require('fs');
+
+          fs.writeFileSync(`${name}.zip`, Buffer.from(result.data));
+
+          return 'true';
+        result-encoding: string
+
+    - name: Unzip blob report
+      if: ${{ steps.artifact.outputs.result == 'true' }}
+      run: unzip ${{ inputs.name }}.zip -d ${{ inputs.path }}
+      shell: bash


### PR DESCRIPTION
Экшен позволяет вытаскивать опр-ый артефакт из другого воркфлоу. Использует [actions/github-script](https://github.com/actions/github-script). Основан на примере из доки [Использование данных из рабочего процесса, активирующего триггер](https://docs.github.com/ru/actions/using-workflows/events-that-trigger-workflows#using-data-from-the-triggering-workflow).

[actions/download-artifact@v3](https://github.com/actions/download-artifact/tree/v3) не умеет в такое (см. issue [actions/download-artifact#3](https://togithub.com/actions/download-artifact/issues/3)).

> **Note**
> Есть альтернатива [dawidd6/action-download-artifact](https://github.com/dawidd6/action-download-artifact), но этот экшен не верифицированный. Пробовал запросить у @VKCOM/vk-sec, но чёт там дело замялось. Да и выяснил, что `actions/github-script` хватает с головой.

---

- related to https://github.com/VKCOM/VKUI/pull/5631