### PR TITLE
feat(complete-publish): add latest tag processing

### DIFF
--- a/VKUI/complete-publish/action.yml
+++ b/VKUI/complete-publish/action.yml
@@ -7,6 +7,9 @@ inputs:
   releaseTag:
     required: true
     description: "released version's tag"
+  latest:
+    required: true
+    description: 'latest tag for release'
 runs:
   using: 'node16'
   main: 'dist/index.js'

--- a/VKUI/complete-publish/src/main.ts
+++ b/VKUI/complete-publish/src/main.ts
@@ -5,10 +5,11 @@ async function run(): Promise<void> {
   try {
     const token = core.getInput('token', { required: true });
     const releaseTag = core.getInput('releaseTag', { required: true });
+    const latest = core.getInput('latest', { required: true });
 
     const workflow = new WorkflowHandler(token, releaseTag);
 
-    await workflow.processReleaseNotes();
+    await workflow.processReleaseNotes(latest === 'true');
     await workflow.processMilestone();
 
     if (workflow.isProcessWithError()) {

--- a/VKUI/complete-publish/src/workflowHandler.ts
+++ b/VKUI/complete-publish/src/workflowHandler.ts
@@ -45,7 +45,7 @@ export class WorkflowHandler {
     }
   }
 
-  public async processReleaseNotes() {
+  public async processReleaseNotes(latest: boolean) {
     try {
       const releaseNotes = await this.findReleaseNotes();
 
@@ -53,7 +53,7 @@ export class WorkflowHandler {
         throw new Error(`There are no release notes for ${this.releaseTag}`);
       }
 
-      await this.publishReleaseNotes(releaseNotes.id);
+      await this.publishReleaseNotes(releaseNotes.id, latest);
     } catch (error) {
       if (error instanceof Error) {
         core.error(error.message);
@@ -74,13 +74,14 @@ export class WorkflowHandler {
     return releases.find(({ draft, name }) => draft && name === this.releaseTag);
   }
 
-  private async publishReleaseNotes(release_id: number) {
+  private async publishReleaseNotes(release_id: number, latest: boolean) {
     await this.gh.rest.repos.updateRelease({
       ...github.context.repo,
       tag_name: this.releaseTag,
       release_id,
       draft: false,
       prerelease: this.releaseTag.includes('-'),
+      make_latest: latest,
     });
   }
 


### PR DESCRIPTION
Добавляем поддержку тега `latest`, на случай, если потребуется выпускать релизы не к текущей мажорной верии