### PR TITLE
fix: Ignore issues with locked discussions

### DIFF
--- a/VKUI/complete-publish/src/workflowHandler.ts
+++ b/VKUI/complete-publish/src/workflowHandler.ts
@@ -108,7 +108,7 @@ export class WorkflowHandler {
     });
 
     return issues.reduce<number[]>((issueNumbers, issue) => {
-      if (issue.state_reason !== IGNORED_STATE) {
+      if (issue.state_reason !== IGNORED_STATE && !issue.locked) {
         issueNumbers.push(issue.number);
       }
       return issueNumbers;


### PR DESCRIPTION
При публикации [v6](https://github.com/VKCOM/VKUI/actions/runs/7543985854) для VKUI не смогли полностью закрыть `milestone`, потому что попалась [issue](https://github.com/VKCOM/VKUI/issues/2684), которая была конвертирована в дискуссию.

Решение: фильтруем по полю `locked` дополнительно, чтобы не пытаться писать в закрытые от обсуждений `issue`.