### PR TITLE
feat: process issues by tag label

### DIFF
--- a/VKUI/complete-publish/src/main.ts
+++ b/VKUI/complete-publish/src/main.ts
@@ -10,6 +10,7 @@ async function run(): Promise<void> {
     const workflow = new WorkflowHandler(token, releaseTag);
 
     await workflow.processReleaseNotes(latest === 'true');
+    await workflow.processIssuesByTagLabel();
     await workflow.processMilestone();
 
     if (workflow.isProcessWithError()) {


### PR DESCRIPTION
Т.к. гитхаб позволяет навешивать только один `milestone` на `issue`, а нам требуется иногда возможность навесить несколько, обходим такое ограничение заданием `label`'а для `issue`, который соответствует нужному `mileston`у

~~Смотря какой fabric, смотря сколько details~~