### PR TITLE
feat: update peter-evans/create-pull-request@v6

### DIFF
--- a/shared/rust/cargo-update-pr/action.yml
+++ b/shared/rust/cargo-update-pr/action.yml
@@ -19,7 +19,7 @@ runs:
       shell: bash
 
     - name: Create Pull Request
-      uses: peter-evans/create-pull-request@v5
+      uses: peter-evans/create-pull-request@v6
       with:
         title: Cargo update
         branch: github-actions/build/deps/cargo-update


### PR DESCRIPTION
> - The default values for author and committer have changed. See "What's new" below for details. If you are overriding the default values you will not be affected by this change.
> - On completion, the action now removes the temporary git remote configuration it adds when using push-to-fork. This should not affect you unless you were using the temporary configuration for some other purpose after the action completes.

https://github.com/peter-evans/create-pull-request/blob/main/docs/updating.md#updating-from-v5-to-v6