### PR TITLE
fix: esbuild packages bundle

### DIFF
--- a/VKUI/complete-publish/package.json
+++ b/VKUI/complete-publish/package.json
@@ -15,7 +15,7 @@
   },
   "scripts": {
     "prebuild": "shx rm -rf dist/*",
-    "build": "esbuild ./src/main.ts --bundle --outfile=dist/index.js --platform=node",
+    "build": "esbuild ./src/main.ts --bundle --outfile=dist/index.js --platform=node --packages=bundle",
     "test": "jest --passWithNoTests"
   }
 }

--- a/VKUI/patch/package.json
+++ b/VKUI/patch/package.json
@@ -17,7 +17,7 @@
   },
   "scripts": {
     "prebuild": "shx rm -rf dist/*",
-    "build": "esbuild ./src/main.ts --bundle --outfile=dist/index.js --platform=node",
+    "build": "esbuild ./src/main.ts --bundle --outfile=dist/index.js --platform=node --packages=bundle",
     "test": "jest --passWithNoTests"
   }
 }

--- a/VKUI/push-screenshots/package.json
+++ b/VKUI/push-screenshots/package.json
@@ -14,7 +14,7 @@
   },
   "scripts": {
     "prebuild": "shx rm -rf dist/*",
-    "build": "esbuild ./src/main.ts --bundle --outfile=dist/index.js --platform=node",
+    "build": "esbuild ./src/main.ts --bundle --outfile=dist/index.js --platform=node --packages=bundle",
     "test": "jest --passWithNoTests"
   }
 }

--- a/VKUI/reporter/package.json
+++ b/VKUI/reporter/package.json
@@ -15,7 +15,7 @@
   },
   "scripts": {
     "prebuild": "shx rm -rf dist/*",
-    "build": "esbuild ./src/main.ts --bundle --outfile=dist/index.js --platform=node",
+    "build": "esbuild ./src/main.ts --bundle --outfile=dist/index.js --platform=node --packages=bundle",
     "test": "jest --passWithNoTests"
   }
 }

--- a/VKUI/s3/package.json
+++ b/VKUI/s3/package.json
@@ -16,7 +16,7 @@
   },
   "scripts": {
     "prebuild": "shx rm -rf dist/*",
-    "build": "esbuild ./src/main.ts --bundle --outfile=dist/index.js --platform=node",
+    "build": "esbuild ./src/main.ts --bundle --outfile=dist/index.js --platform=node --packages=bundle",
     "test": "jest --passWithNoTests"
   }
 }

--- a/VKUI/size-upload/package.json
+++ b/VKUI/size-upload/package.json
@@ -17,7 +17,7 @@
   },
   "scripts": {
     "prebuild": "shx rm -rf dist/*",
-    "build": "esbuild ./src/main.ts --bundle --outfile=dist/index.js --platform=node",
+    "build": "esbuild ./src/main.ts --bundle --outfile=dist/index.js --platform=node --packages=bundle",
     "test": "jest --passWithNoTests"
   }
 }

--- a/VKUI/stable-branch/package.json
+++ b/VKUI/stable-branch/package.json
@@ -17,7 +17,7 @@
   },
   "scripts": {
     "prebuild": "shx rm -rf dist/*",
-    "build": "esbuild ./src/main.ts --bundle --outfile=dist/index.js --platform=node",
+    "build": "esbuild ./src/main.ts --bundle --outfile=dist/index.js --platform=node --packages=bundle",
     "test": "jest --passWithNoTests"
   }
 }

--- a/shared/rust/cargo-update-toml/package.json
+++ b/shared/rust/cargo-update-toml/package.json
@@ -13,7 +13,7 @@
   },
   "scripts": {
     "prebuild": "shx rm -rf dist/*",
-    "build": "esbuild ./src/main.ts --bundle --outfile=dist/index.js --platform=node",
+    "build": "esbuild ./src/main.ts --bundle --outfile=dist/index.js --platform=node --packages=bundle",
     "test": "jest --passWithNoTests"
   }
 }

--- a/vkui-tokens/token-base/package.json
+++ b/vkui-tokens/token-base/package.json
@@ -18,7 +18,7 @@
   },
   "scripts": {
     "prebuild": "shx rm -rf dist/*",
-    "build": "esbuild ./src/main.ts --bundle --outfile=dist/index.js --platform=node",
+    "build": "esbuild ./src/main.ts --bundle --outfile=dist/index.js --platform=node --packages=bundle",
     "test": "jest --passWithNoTests"
   }
 }


### PR DESCRIPTION
После мажорного обновление esbuild-а для бандлинга js-а нужен отдельный флаг

- cause #395