### PR TITLE
tech: fix getting latest vkui version

### DIFF
--- a/VKUI/auto-update-release-notes/action.yml
+++ b/VKUI/auto-update-release-notes/action.yml
@@ -8,10 +8,6 @@ inputs:
   token:
     required: true
     description: 'token with access to your repository'
-
-  current_vkui_version:
-    required: true
-    description: 'current vkui package version'
 runs:
   using: 'node20'
   main: 'dist/index.js'

--- a/VKUI/auto-update-release-notes/src/calculateReleaseVersion.ts
+++ b/VKUI/auto-update-release-notes/src/calculateReleaseVersion.ts
@@ -1,19 +1,45 @@
 import { getNextReleaseVersion } from './getVersion';
+import * as github from '@actions/github';
 
-export function calculateReleaseVersion({
+const parseReleaseVersion = (releaseVersion: string): string | null => {
+  const match = releaseVersion.match(/v(\d+\.\d+\.\d+)/);
+  return match?.[1] || null;
+};
+
+export async function calculateReleaseVersion({
+  octokit,
+  owner,
+  repo,
   labels,
   milestone,
-  currentVKUIVersion,
 }: {
+  octokit: ReturnType<typeof github.getOctokit>;
+  owner: string;
+  repo: string;
   labels: Array<{ name: string }>;
   milestone: { title: string } | null;
-  currentVKUIVersion: string;
-}) {
+}): Promise<string | null> {
+  if (milestone?.title) {
+    return parseReleaseVersion(milestone.title);
+  }
+  let latestRelease;
+  try {
+    latestRelease = await octokit.rest.repos.getLatestRelease({
+      repo,
+      owner,
+    });
+  } catch (e) {
+    return null;
+  }
+
+  const latestVersion = latestRelease.data.name && parseReleaseVersion(latestRelease.data.name);
+
+  if (!latestVersion) {
+    return null;
+  }
+
   const hasPatchLabel = labels.some((label) => label.name === 'patch');
+  const updateType = hasPatchLabel ? 'patch' : 'minor';
 
-  const nextReleaseVersion =
-    milestone?.title ||
-    `v${getNextReleaseVersion(currentVKUIVersion, hasPatchLabel ? 'patch' : 'minor')}`;
-
-  return nextReleaseVersion;
+  return getNextReleaseVersion(latestVersion, updateType);
 }

--- a/VKUI/auto-update-release-notes/src/getRelease.ts
+++ b/VKUI/auto-update-release-notes/src/getRelease.ts
@@ -48,12 +48,13 @@ export async function getRelease({
   repo: string;
   releaseVersion: string;
 }) {
+  const releaseName = `v${releaseVersion}`;
   try {
     const searchedRelease = await getRecentDraftReleaseByName({
       octokit,
       owner,
       repo,
-      releaseName: releaseVersion,
+      releaseName,
     });
     return searchedRelease;
   } catch (e) {
@@ -61,8 +62,8 @@ export async function getRelease({
       const { data: createdRelease } = await octokit.rest.repos.createRelease({
         owner,
         repo,
-        tag_name: releaseVersion,
-        name: releaseVersion,
+        tag_name: releaseName,
+        name: releaseName,
         body: '',
         draft: true,
         prerelease: false,

--- a/VKUI/auto-update-release-notes/src/getRelease.ts
+++ b/VKUI/auto-update-release-notes/src/getRelease.ts
@@ -56,20 +56,22 @@ export async function getRelease({
       repo,
       releaseName,
     });
-    return searchedRelease;
-  } catch (e) {
-    if (e instanceof Error && 'status' in e && e.status === 404) {
-      const { data: createdRelease } = await octokit.rest.repos.createRelease({
-        owner,
-        repo,
-        tag_name: releaseName,
-        name: releaseName,
-        body: '',
-        draft: true,
-        prerelease: false,
-      });
-      return createdRelease;
+    if (searchedRelease) {
+      return searchedRelease;
     }
-  }
+  } catch (e) {}
+  try {
+    const { data: createdRelease } = await octokit.rest.repos.createRelease({
+      owner,
+      repo,
+      tag_name: releaseName,
+      name: releaseName,
+      body: '',
+      draft: true,
+      prerelease: false,
+    });
+    return createdRelease;
+  } catch (e) {}
+
   return null;
 }

--- a/VKUI/auto-update-release-notes/src/getVersion.ts
+++ b/VKUI/auto-update-release-notes/src/getVersion.ts
@@ -14,12 +14,12 @@ function getNextPatchVersion(currentVersion: string): string {
   return nextVersion;
 }
 
-export function getNextReleaseVersion(currentVKUIVersion: string, updateType: 'patch' | 'minor') {
+export function getNextReleaseVersion(lastVKUIVersion: string, updateType: 'patch' | 'minor') {
   switch (updateType) {
     case 'minor':
-      return getNextMinorVersion(currentVKUIVersion);
+      return getNextMinorVersion(lastVKUIVersion);
     case 'patch':
-      return getNextPatchVersion(currentVKUIVersion);
+      return getNextPatchVersion(lastVKUIVersion);
   }
-  return currentVKUIVersion;
+  return lastVKUIVersion;
 }

--- a/VKUI/auto-update-release-notes/src/main.ts
+++ b/VKUI/auto-update-release-notes/src/main.ts
@@ -5,7 +5,6 @@ import { updateReleaseNotes } from './updateReleaseNotes';
 async function run() {
   const token = core.getInput('token', { required: true });
   const prNumber = Number(core.getInput('pull_request_number', { required: true }));
-  const currentVKUIVersion = core.getInput('current_vkui_version', { required: true });
   const octokit = github.getOctokit(token);
 
   const { owner, repo } = github.context.repo;
@@ -15,7 +14,6 @@ async function run() {
     prNumber,
     owner,
     repo,
-    currentVKUIVersion,
   });
 }
 

--- a/VKUI/auto-update-release-notes/src/parsing/releaseNotesUpdater.ts
+++ b/VKUI/auto-update-release-notes/src/parsing/releaseNotesUpdater.ts
@@ -73,7 +73,7 @@ export function releaseNotesUpdater(currentBody: string) {
   const addUndescribedPRNumber = (prNumber: number) => {
     if (body.includes(NEED_TO_DESCRIBE_HEADER)) {
       insertContentInSection(NEED_TO_DESCRIBE_HEADER, (currentContent) => {
-        currentContent += `#${prNumber}\n`;
+        currentContent += `\n#${prNumber}`;
         return currentContent;
       });
     } else {

--- a/VKUI/auto-update-release-notes/src/updateReleaseNotes.test.ts
+++ b/VKUI/auto-update-release-notes/src/updateReleaseNotes.test.ts
@@ -22,6 +22,8 @@ const setupData = () => {
     Awaited<ReturnType<Octokit['rest']['repos']['getReleaseByTag']>>['data']
   > | null = null;
 
+  let lastReleaseName = '';
+
   const octokit = {
     rest: {
       pulls: {
@@ -57,6 +59,13 @@ const setupData = () => {
             data: [releaseData],
           };
         }) as Octokit['rest']['repos']['listReleases'],
+        getLatestRelease: (async () => {
+          return {
+            data: {
+              name: lastReleaseName,
+            },
+          };
+        }) as Octokit['rest']['repos']['getLatestRelease'],
         createRelease: (async (options) => {
           createReleaseRequest(options);
           releaseData = {
@@ -79,6 +88,9 @@ const setupData = () => {
     createReleaseRequest,
     updateReleaseRequest,
     octokit: octokit as unknown as Octokit,
+    set lastReleaseName(name: string) {
+      lastReleaseName = name;
+    },
     set pullRequestData(
       data: Partial<Omit<typeof pullRequestData, 'user' | 'labels'>> & {
         user?: Partial<(typeof pullRequestData)['user']>;
@@ -181,12 +193,13 @@ describe('run updateReleaseNotes', () => {
       },
     };
 
+    mockedData.lastReleaseName = 'v6.5.1';
+
     await updateReleaseNotes({
       octokit: mockedData.octokit,
       owner: 'owner',
       repo: 'repo',
       prNumber: 1234,
-      currentVKUIVersion: '6.5.1',
     });
     expect(mockedData.createReleaseRequest).toHaveBeenCalledTimes(0);
     expect(mockedData.getReleaseRequest).toHaveBeenCalledWith({
@@ -282,12 +295,13 @@ describe('run updateReleaseNotes', () => {
       },
     };
 
+    mockedData.lastReleaseName = 'v6.5.1';
+
     await updateReleaseNotes({
       octokit: mockedData.octokit,
       owner: 'owner',
       repo: 'repo',
       prNumber: 1234,
-      currentVKUIVersion: '6.5.1',
     });
     expect(mockedData.createReleaseRequest).toHaveBeenCalledTimes(0);
     expect(mockedData.getReleaseRequest).toHaveBeenCalledWith({
@@ -357,13 +371,13 @@ describe('run updateReleaseNotes', () => {
         login: 'eldar',
       },
     };
+    mockedData.lastReleaseName = 'v6.5.1';
 
     await updateReleaseNotes({
       octokit: mockedData.octokit,
       owner: 'owner',
       repo: 'repo',
       prNumber: 1234,
-      currentVKUIVersion: '6.5.1',
     });
     expect(mockedData.createReleaseRequest).toHaveBeenCalledTimes(0);
     expect(mockedData.getReleaseRequest).toHaveBeenCalledWith({
@@ -421,12 +435,13 @@ describe('run updateReleaseNotes', () => {
       ],
     };
 
+    mockedData.lastReleaseName = 'v6.5.1';
+
     await updateReleaseNotes({
       octokit: mockedData.octokit,
       owner: 'owner',
       repo: 'repo',
       prNumber: 1234,
-      currentVKUIVersion: '6.5.1',
     });
     expect(mockedData.createReleaseRequest).toHaveBeenCalledTimes(0);
     expect(mockedData.getReleaseRequest).toHaveBeenCalledWith({

--- a/VKUI/auto-update-release-notes/src/updateReleaseNotes.ts
+++ b/VKUI/auto-update-release-notes/src/updateReleaseNotes.ts
@@ -13,13 +13,11 @@ export const updateReleaseNotes = async ({
   owner,
   repo,
   prNumber,
-  currentVKUIVersion,
 }: {
   octokit: ReturnType<typeof github.getOctokit>;
   owner: string;
   repo: string;
   prNumber: number;
-  currentVKUIVersion: string;
 }) => {
   let pullRequest;
   try {
@@ -50,11 +48,16 @@ export const updateReleaseNotes = async ({
     pullRequestReleaseNotesBody &&
     parsePullRequestReleaseNotesBody(pullRequestReleaseNotesBody, prNumber);
 
-  const releaseVersion = calculateReleaseVersion({
+  const releaseVersion = await calculateReleaseVersion({
+    octokit,
+    repo,
+    owner,
     labels: pullRequestLabels,
     milestone: pullRequest.milestone,
-    currentVKUIVersion,
   });
+  if (!releaseVersion) {
+    return;
+  }
 
   const release = await getRelease({
     owner,
@@ -75,7 +78,7 @@ export const updateReleaseNotes = async ({
     pullRequestReleaseNotes.forEach((note) => {
       releaseUpdater.addNotes({
         noteData: note,
-        version: releaseVersion.slice(1),
+        version: releaseVersion,
         author: isVKCOMember ? '' : author,
       });
     });


### PR DESCRIPTION
## Описание

Сейчас последняя версия библиотеки `VKUI` рассчитывается путем получения версии из `package.json `в пакете `VKUI`.  Это не совсем правильно, так как патчевые изменения не попадают в `package.json`. Поэтому рассчитать следующую версию для PR в скрипте `auto-update-release-notes` не всегда удается корректно. Нужно рассчитывать актуальную версию исходя из последнего опубликованного релиза

## Изменения

- Реализовал расчет актуальной версии VKUI через метод getLatestRelease, который возвращает последний опубликованный релиз. Из названия этого релиза достаем актуальную версию библиотеки
- Доработал тесты для нового поведения
- Убрал из inputs `current_vkui_version`, так этот параметр больше не нужен