### PR TITLE
tech: fix parsing of release notes

### DIFF
--- a/VKUI/auto-update-release-notes/src/checkVKCOMMember.ts
+++ b/VKUI/auto-update-release-notes/src/checkVKCOMMember.ts
@@ -1,4 +1,5 @@
 import * as github from '@actions/github';
+import * as core from '@actions/core';
 
 type Octokit = ReturnType<typeof github.getOctokit>;
 
@@ -10,10 +11,15 @@ export const checkVKCOMMember = async ({
   author: string;
 }) => {
   try {
+    core.debug(`[checkVKCOMMember] author: ${author}`);
     // Проверяем, принадлежит ли автор к организации VKCOM
     const { data: orgs } = await octokit.rest.orgs.listForUser({
       username: author,
     });
+
+    core.debug(
+      `[checkVKCOMMember] organization: ${JSON.stringify(orgs.map(({ login }) => login))}`,
+    );
 
     const isVKCOMMember = orgs.some((org) => org.login === 'VKCOM');
 

--- a/VKUI/auto-update-release-notes/src/parsing/convertChangesToString.ts
+++ b/VKUI/auto-update-release-notes/src/parsing/convertChangesToString.ts
@@ -42,7 +42,7 @@ export const convertChangesToString = (
 
   const addAdditionalInfo = (change: ChangeData) => {
     if (change.additionalInfo) {
-      result += `${change.additionalInfo}\n`;
+      result += `${change.additionalInfo}\r\n`;
     }
   };
 
@@ -54,16 +54,16 @@ export const convertChangesToString = (
       }
       result += `- ${componentToString(change.component, version)}:`;
       if (componentChanges.length > 1) {
-        result += '\n';
+        result += '\r\n';
         componentChanges.forEach((changeItem) => {
-          result += `  -${changeDescriptionToString(changeItem, author)}\n`;
+          result += `  -${changeDescriptionToString(changeItem, author)}\r\n`;
           addAdditionalInfo(changeItem);
         });
       } else {
-        result += `${changeDescriptionToString(change, author)}\n`;
+        result += `${changeDescriptionToString(change, author)}\r\n`;
       }
     } else {
-      result += `-${changeDescriptionToString(change, author)}\n`;
+      result += `-${changeDescriptionToString(change, author)}\r\n`;
       addAdditionalInfo(change);
     }
   });

--- a/VKUI/auto-update-release-notes/src/parsing/getPullRequestReleaseNotesBody.ts
+++ b/VKUI/auto-update-release-notes/src/parsing/getPullRequestReleaseNotesBody.ts
@@ -1,4 +1,4 @@
-const RELEASE_NOTE_HEADER = '## Release notes\n';
+const RELEASE_NOTE_HEADER = '## Release notes';
 
 export const getPullRequestReleaseNotesBody = (body: string): string | null => {
   const releaseNotesIndex = body.indexOf(RELEASE_NOTE_HEADER);

--- a/VKUI/auto-update-release-notes/src/parsing/parseChanges.ts
+++ b/VKUI/auto-update-release-notes/src/parsing/parseChanges.ts
@@ -7,7 +7,7 @@ const UNKNOWN_CHANGE_REGEX = /-\s(.+)/;
 
 export function parseChanges(text: string): ChangeData[] {
   let changes: ChangeData[] = [];
-  const lines = text.split('\n');
+  const lines = text.split(/\r?\n/);
   let currentChange: ChangeData | null = null;
 
   for (let i = 0; i < lines.length; i++) {
@@ -51,7 +51,7 @@ export function parseChanges(text: string): ChangeData[] {
       changes.push(currentChange);
     } else if (line.trim() && currentChange) {
       // Дополнительная информация
-      currentChange.additionalInfo += `${line}\n`;
+      currentChange.additionalInfo += `${line}\r\n`;
     } else if (line) {
       // Если строка не пустая и не относится к текущему изменению,
       // создаем новое неизвестное изменение

--- a/VKUI/auto-update-release-notes/src/parsing/releaseNotesUpdater.ts
+++ b/VKUI/auto-update-release-notes/src/parsing/releaseNotesUpdater.ts
@@ -14,7 +14,7 @@ export function releaseNotesUpdater(currentBody: string) {
 
   const getReleaseNotesData = (): ReleaseNoteData[] => {
     const releaseNotesData: ReleaseNoteData[] = [];
-    const sectionRegex = /## (.+)\n([\s\S]*?)(?=##|$)/g;
+    const sectionRegex = /## (.+)\r?\n([\s\S]*?)(?=##|$)/g;
     const matches = body.matchAll(sectionRegex);
     for (const match of matches) {
       const [, header, content] = match;
@@ -41,7 +41,7 @@ export function releaseNotesUpdater(currentBody: string) {
     const endIndex = findNextHeaderPosition(startIndex);
     let currentContent = body.substring(startIndex, endIndex).trim();
     currentContent = calculateNewContent(currentContent);
-    body = body.slice(0, startIndex) + '\n' + currentContent + '\n' + body.slice(endIndex);
+    body = body.slice(0, startIndex) + '\r\n' + currentContent + '\r\n' + body.slice(endIndex);
   };
 
   const addNotes = ({
@@ -65,7 +65,7 @@ export function releaseNotesUpdater(currentBody: string) {
         return convertChangesToString(currentSectionContentData, version, author || '');
       });
     } else {
-      body += `\n## ${getHeaderBySectionType(noteData.type)}\n`;
+      body += `\r\n## ${getHeaderBySectionType(noteData.type)}\r\n`;
       body += convertChangesToString(noteData.data, version, author || '');
     }
   };
@@ -73,11 +73,11 @@ export function releaseNotesUpdater(currentBody: string) {
   const addUndescribedPRNumber = (prNumber: number) => {
     if (body.includes(NEED_TO_DESCRIBE_HEADER)) {
       insertContentInSection(NEED_TO_DESCRIBE_HEADER, (currentContent) => {
-        currentContent += `\n#${prNumber}`;
+        currentContent += `\r\n#${prNumber}`;
         return currentContent;
       });
     } else {
-      body += `\n## ${NEED_TO_DESCRIBE_HEADER}\n`;
+      body += `\r\n## ${NEED_TO_DESCRIBE_HEADER}\r\n`;
       body += `#${prNumber}`;
     }
   };

--- a/VKUI/auto-update-release-notes/src/updateReleaseNotes.test.ts
+++ b/VKUI/auto-update-release-notes/src/updateReleaseNotes.test.ts
@@ -213,34 +213,34 @@ describe('run updateReleaseNotes', () => {
       repo: 'repo',
       release_id: 123,
       body: `
-## Новые компоненты
-- Новый компонент с название COMPONENT
-- Новый компонент с название COMPONENT2 (#1234, спасибо @other)
-Картинка с новым компонентом
-Какая-то доп информация
-- Новый компонент с название COMPONENT3 (#1234, спасибо @other)
-
-## Улучшения
-- [ChipsSelect](https://vkcom.github.io/VKUI/6.6.0/#/ChipsSelect):
-  - Улучшение компонента ChipsSelect (#7023)
-  - Улучшение компонента ChipsSelect 2 (#1234, спасибо @other)
-Немного подробнее об этом. Можно приложить картинку
-- [ChipsInput](https://vkcom.github.io/VKUI/6.6.0/#/ChipsInput): Улучшение компонента ChipsInput (#1234, спасибо @other)
-
-## Исправления
-- [List](https://vkcom.github.io/VKUI/6.6.0/#/List):
-  - Исправление компонента List (#7094)
-  - Исправление компонента List 2 (#1234, спасибо @other)
-- [Flex](https://vkcom.github.io/VKUI/6.6.0/#/Flex): Исправление компонента Flex (#1234, спасибо @other)
-
-## Зависимости
-- Обновлена какая-то зависимость 1
-- Обновлена какая-то зависимость 2 (#1234, спасибо @other)
-
-## Документация
-- [CustomScrollView](https://vkcom.github.io/VKUI/6.6.0/#/CustomScrollView): Обновлена документация CustomScrollView
-- Поправлены баги в документации (#1234, спасибо @other)
-
+## Новые компоненты\r
+- Новый компонент с название COMPONENT\r
+- Новый компонент с название COMPONENT2 (#1234, спасибо @other)\r
+Картинка с новым компонентом\r
+Какая-то доп информация\r
+- Новый компонент с название COMPONENT3 (#1234, спасибо @other)\r
+\r
+## Улучшения\r
+- [ChipsSelect](https://vkcom.github.io/VKUI/6.6.0/#/ChipsSelect):\r
+  - Улучшение компонента ChipsSelect (#7023)\r
+  - Улучшение компонента ChipsSelect 2 (#1234, спасибо @other)\r
+Немного подробнее об этом. Можно приложить картинку\r
+- [ChipsInput](https://vkcom.github.io/VKUI/6.6.0/#/ChipsInput): Улучшение компонента ChipsInput (#1234, спасибо @other)\r
+\r
+## Исправления\r
+- [List](https://vkcom.github.io/VKUI/6.6.0/#/List):\r
+  - Исправление компонента List (#7094)\r
+  - Исправление компонента List 2 (#1234, спасибо @other)\r
+- [Flex](https://vkcom.github.io/VKUI/6.6.0/#/Flex): Исправление компонента Flex (#1234, спасибо @other)\r
+\r
+## Зависимости\r
+- Обновлена какая-то зависимость 1\r
+- Обновлена какая-то зависимость 2 (#1234, спасибо @other)\r
+\r
+## Документация\r
+- [CustomScrollView](https://vkcom.github.io/VKUI/6.6.0/#/CustomScrollView): Обновлена документация CustomScrollView\r
+- Поправлены баги в документации (#1234, спасибо @other)\r
+\r
 `,
     });
   });
@@ -315,27 +315,27 @@ describe('run updateReleaseNotes', () => {
       repo: 'repo',
       release_id: 123,
       body: `
-## Новые компоненты
-- Новый компонент с название COMPONENT
-- Новый компонент с название COMPONENT2 (#1234)
-- Новый компонент с название COMPONENT3 (#1234)
-
-## Исправления
-- [List](https://vkcom.github.io/VKUI/6.6.0/#/List):
-  - Исправление компонента List (#7094)
-  - Исправление компонента List 2 (#1234)
-- [Flex](https://vkcom.github.io/VKUI/6.6.0/#/Flex): Исправление компонента Flex (#1234)
-
-## Документация
-- [CustomScrollView](https://vkcom.github.io/VKUI/6.6.0/#/CustomScrollView): Обновлена документация CustomScrollView
-- Поправлены баги в документации (#1234)
-
-## Улучшения
-- [ChipsSelect](https://vkcom.github.io/VKUI/6.6.0/#/ChipsSelect): Улучшение компонента ChipsSelect 2 (#1234)
-- [ChipsInput](https://vkcom.github.io/VKUI/6.6.0/#/ChipsInput): Улучшение компонента ChipsInput (#1234)
-
-## Зависимости
-- Обновлена какая-то зависимость 2 (#1234)
+## Новые компоненты\r
+- Новый компонент с название COMPONENT\r
+- Новый компонент с название COMPONENT2 (#1234)\r
+- Новый компонент с название COMPONENT3 (#1234)\r
+\r
+## Исправления\r
+- [List](https://vkcom.github.io/VKUI/6.6.0/#/List):\r
+  - Исправление компонента List (#7094)\r
+  - Исправление компонента List 2 (#1234)\r
+- [Flex](https://vkcom.github.io/VKUI/6.6.0/#/Flex): Исправление компонента Flex (#1234)\r
+\r
+## Документация\r
+- [CustomScrollView](https://vkcom.github.io/VKUI/6.6.0/#/CustomScrollView): Обновлена документация CustomScrollView\r
+- Поправлены баги в документации (#1234)\r
+\r
+## Улучшения\r
+- [ChipsSelect](https://vkcom.github.io/VKUI/6.6.0/#/ChipsSelect): Улучшение компонента ChipsSelect 2 (#1234)\r
+- [ChipsInput](https://vkcom.github.io/VKUI/6.6.0/#/ChipsInput): Улучшение компонента ChipsInput (#1234)\r
+\r
+## Зависимости\r
+- Обновлена какая-то зависимость 2 (#1234)\r
 `,
     });
   });
@@ -399,8 +399,8 @@ describe('run updateReleaseNotes', () => {
 
 ## Документация
 - [CustomScrollView](https://vkcom.github.io/VKUI/6.5.0/#/CustomScrollView): Обновлена документация CustomScrollView
-
-## Нужно описать
+\r
+## Нужно описать\r
 #1234`,
     });
   });

--- a/VKUI/auto-update-release-notes/src/updateReleaseNotes.ts
+++ b/VKUI/auto-update-release-notes/src/updateReleaseNotes.ts
@@ -33,18 +33,12 @@ export const updateReleaseNotes = async ({
   if (!pullRequest) {
     return;
   }
-  core.debug(`[updateReleaseNotes] pull request: ${JSON.stringify(pullRequest)}`);
-  core.debug(`[updateReleaseNotes] pull request body: ${pullRequest.body}`);
   const pullRequestBody = pullRequest.body;
   const pullRequestLabels = pullRequest.labels;
   const author = pullRequest.user.login;
 
   const pullRequestReleaseNotesBody =
     pullRequestBody && getPullRequestReleaseNotesBody(pullRequestBody);
-
-  core.debug(
-    `[updateReleaseNotes] pull request pullRequestReleaseNotesBody: ${pullRequestReleaseNotesBody}`,
-  );
 
   if (pullRequestReleaseNotesBody === EMPTY_NOTES) {
     return;
@@ -53,10 +47,6 @@ export const updateReleaseNotes = async ({
   const pullRequestReleaseNotes =
     pullRequestReleaseNotesBody &&
     parsePullRequestReleaseNotesBody(pullRequestReleaseNotesBody, prNumber);
-
-  core.debug(
-    `[updateReleaseNotes] pullRequestReleaseNotes count: ${pullRequestReleaseNotes?.length}`,
-  );
 
   const releaseVersion = await calculateReleaseVersion({
     octokit,
@@ -77,7 +67,6 @@ export const updateReleaseNotes = async ({
     octokit,
     releaseVersion,
   });
-  core.debug(`[updateReleaseNotes] release: ${JSON.stringify(release)}`);
 
   if (!release || !release.draft) {
     return;
@@ -100,8 +89,6 @@ export const updateReleaseNotes = async ({
   } else {
     releaseUpdater.addUndescribedPRNumber(prNumber);
   }
-
-  core.debug(`[updateReleaseNotes] result release notes: ${releaseUpdater.getBody()}`);
 
   await octokit.rest.repos.updateRelease({
     owner,


### PR DESCRIPTION
## Описание

Сейчас есть проблема, что в body pull request'а перенос строки обозначается через `\r\n`, а в коде рассчитывалось что перенос строки это `\n`. Из-за этого неправильно парсятся release notes и в целом неправильно работает скрипт

## Изменения

- Добавил поддержку переноса строки через `\r\n` в коде, поправил парсинг
- Добавил пару логов для проверки остального функционала