### PR TITLE
fix: fix pull request body getting

### DIFF
--- a/VKUI/auto-update-release-notes/src/parsing/getPullRequestReleaseNotesBody.ts
+++ b/VKUI/auto-update-release-notes/src/parsing/getPullRequestReleaseNotesBody.ts
@@ -1,10 +1,13 @@
 const RELEASE_NOTE_HEADER = '## Release notes';
+const COMMENT_START = '<!-- ';
 
 export const getPullRequestReleaseNotesBody = (body: string): string | null => {
   const releaseNotesIndex = body.indexOf(RELEASE_NOTE_HEADER);
   if (releaseNotesIndex === -1) {
     return null;
   }
+  const commentStart = body.indexOf(COMMENT_START, releaseNotesIndex);
+  const end = commentStart !== -1 ? commentStart : body.length;
 
-  return body.slice(releaseNotesIndex + RELEASE_NOTE_HEADER.length).trim();
+  return body.slice(releaseNotesIndex + RELEASE_NOTE_HEADER.length, end).trim();
 };


### PR DESCRIPTION
## Описание

Сейчас есть проблема в том, что при парсинге pull request body, если не удалить комментарий после ReleaseNotes, он тоже попадает под парсинг. В результате мы получаем некорректный результат 

## Изменения

Добавил обрезание комментария перед парсингом release notes в PR