### PR TITLE
feat: add breaking change header support

### DIFF
--- a/VKUI/auto-update-release-notes/src/parsing/headers.ts
+++ b/VKUI/auto-update-release-notes/src/parsing/headers.ts
@@ -5,6 +5,7 @@ export const FIX_HEADER = 'Исправления';
 export const DOCUMENTATION_HEADER = 'Документация';
 export const DEPENDENCY_HEADER = 'Зависимости';
 export const NEW_COMPONENT_HEADER = 'Новые компоненты';
+export const BREAKING_CHANGE_HEADER = 'BREAKING CHANGE';
 export const NEED_TO_DESCRIBE_HEADER = 'Нужно описать';
 
 export const getSectionTypeByHeader = (header: string): SectionType | null => {
@@ -19,6 +20,8 @@ export const getSectionTypeByHeader = (header: string): SectionType | null => {
       return 'dependency';
     case NEW_COMPONENT_HEADER:
       return 'new-component';
+    case BREAKING_CHANGE_HEADER:
+      return 'breaking-change';
   }
   return null;
 };
@@ -35,6 +38,8 @@ export const getHeaderBySectionType = (type: SectionType): string | null => {
       return DEPENDENCY_HEADER;
     case 'new-component':
       return NEW_COMPONENT_HEADER;
+    case 'breaking-change':
+      return BREAKING_CHANGE_HEADER;
   }
   return null;
 };

--- a/VKUI/auto-update-release-notes/src/types.ts
+++ b/VKUI/auto-update-release-notes/src/types.ts
@@ -1,4 +1,10 @@
-export type SectionType = 'improvement' | 'fix' | 'documentation' | 'new-component' | 'dependency';
+export type SectionType =
+  | 'breaking-change'
+  | 'improvement'
+  | 'fix'
+  | 'documentation'
+  | 'new-component'
+  | 'dependency';
 
 type ComponentChangeData = {
   type: 'component';


### PR DESCRIPTION
## Описание

Сейчас для списка breaking changes нет поддержки в скрипте автообновления релиз ноутов

## Изменения

Добавил поддержку заголовка `BREAKING CHANGE` в скрипт обновления релиз ноутов