### PR TITLE
feat: improve calculating releaseName and release version

### DIFF
--- a/VKUI/auto-update-release-notes/src/getRelease.ts
+++ b/VKUI/auto-update-release-notes/src/getRelease.ts
@@ -41,14 +41,13 @@ export async function getRelease({
   octokit,
   owner,
   repo,
-  releaseVersion,
+  releaseName,
 }: {
   octokit: ReturnType<typeof github.getOctokit>;
   owner: string;
   repo: string;
-  releaseVersion: string;
+  releaseName: string;
 }) {
-  const releaseName = `v${releaseVersion}`;
   try {
     const searchedRelease = await getRecentDraftReleaseByName({
       octokit,

--- a/VKUI/auto-update-release-notes/src/updateReleaseNotes.ts
+++ b/VKUI/auto-update-release-notes/src/updateReleaseNotes.ts
@@ -46,7 +46,7 @@ export const updateReleaseNotes = async ({
     pullRequestReleaseNotesBody &&
     parsePullRequestReleaseNotesBody(pullRequestReleaseNotesBody, prNumber);
 
-  const releaseVersion = await calculateReleaseVersion({
+  const releaseData = await calculateReleaseVersion({
     octokit,
     repo,
     owner,
@@ -54,15 +54,17 @@ export const updateReleaseNotes = async ({
     milestone: pullRequest.milestone,
   });
 
-  if (!releaseVersion) {
+  if (!releaseData || !releaseData.version) {
     return;
   }
+
+  const { releaseName, version: releaseVersion } = releaseData;
 
   const release = await getRelease({
     owner,
     repo,
     octokit,
-    releaseVersion,
+    releaseName,
   });
 
   if (!release || !release.draft) {


### PR DESCRIPTION
## Описание

Сейчас скрипт автообновления релиз ноутов некорректно работает с кастомными майлстоунам, например `v7.0.0-beta.0`

## Изменения

- Доработал логику расчет названия релиза на основании title майлстоуна
- Добавил тест покрывающий новую логику
