### PR TITLE
fix: fix parse release notes with code block info

### DIFF
--- a/VKUI/auto-update-release-notes/src/parsing/convertChangesToString.ts
+++ b/VKUI/auto-update-release-notes/src/parsing/convertChangesToString.ts
@@ -44,7 +44,7 @@ export const convertChangesToString = (
     const offsetStr = ' '.repeat(offsetLevel * 2);
     if (change.additionalInfo) {
       change.additionalInfo.split(/\r?\n/).forEach((line) => {
-        result += `${offsetStr}${line.trim()}\r\n`;
+        result += `${offsetStr}${line}\r\n`;
       });
     }
   };

--- a/VKUI/auto-update-release-notes/src/parsing/parseChanges.ts
+++ b/VKUI/auto-update-release-notes/src/parsing/parseChanges.ts
@@ -4,26 +4,53 @@ const COMPONENT_REGEX = /-\s(\w+):(.+)?/;
 const COMPONENT_WITH_LINK_REGEX = /-\s\[(\w+)]\(.+\):(.+)?/;
 const COMPONENT_SUB_ITEM_REGEX = /\s{2}-\s(.+)/;
 const UNKNOWN_CHANGE_REGEX = /-\s(.+)/;
+const CODE_BLOCK_START_REGEX = /```(diff)?/;
+const CODE_BLOCK_END_REGEX = /```/;
+
+function removeLeadingSpaces(str: string, n: number): string {
+  // Создаем регулярное выражение для проверки n пробелов в начале строки
+  const regexStr = `^\\s{${n}}`;
+  const regex = new RegExp(regexStr);
+  return regex.test(str) ? str.slice(n) : str;
+}
 
 export function parseChanges(text: string): ChangeData[] {
   let changes: ChangeData[] = [];
   const lines = text.split(/\r?\n/);
   let currentChange: ChangeData | null = null;
+  let codeBlockStarted = false;
 
   for (let i = 0; i < lines.length; i++) {
-    const line = lines[i].trim();
+    const line = lines[i];
     const componentMatch = line.match(COMPONENT_REGEX);
     const componentWithLinkMatch = line.match(COMPONENT_WITH_LINK_REGEX);
     const componentSubItemMatch = line.match(COMPONENT_SUB_ITEM_REGEX);
     const unknownChangeMatch = line.match(UNKNOWN_CHANGE_REGEX);
+    const codeBlockStartMatch = line.match(CODE_BLOCK_START_REGEX);
+    const codeBlockEndMatch: RegExpMatchArray | null = codeBlockStarted
+      ? line.match(CODE_BLOCK_END_REGEX)
+      : null;
 
-    if (componentMatch || componentWithLinkMatch) {
+    const addToAdditionalInfo = () => {
+      if (currentChange) {
+        const subInfo = currentChange.type === 'component' && currentChange.subInfo;
+        currentChange.additionalInfo += `${removeLeadingSpaces(line, subInfo ? 4 : 2)}\r\n`;
+      }
+    };
+
+    if (codeBlockStartMatch || codeBlockEndMatch) {
+      codeBlockStarted = !codeBlockEndMatch;
+      addToAdditionalInfo();
+    } else if (codeBlockStarted) {
+      addToAdditionalInfo();
+    } else if (componentMatch || componentWithLinkMatch) {
       const match = componentMatch || componentWithLinkMatch;
       if (match) {
         const component = match[1];
         const description = match[2].trim();
         currentChange = {
           type: 'component',
+          subInfo: false,
           component: component,
           description: description,
           additionalInfo: '',
@@ -35,6 +62,7 @@ export function parseChanges(text: string): ChangeData[] {
       const description = componentSubItemMatch[1].trim();
       currentChange = {
         type: 'component',
+        subInfo: true,
         component: currentChange.component,
         description: description,
         additionalInfo: '',
@@ -50,8 +78,7 @@ export function parseChanges(text: string): ChangeData[] {
       };
       changes.push(currentChange);
     } else if (currentChange) {
-      // Дополнительная информация
-      currentChange.additionalInfo += `${line}\r\n`;
+      addToAdditionalInfo();
     } else if (line) {
       // Если строка не пустая и не относится к текущему изменению,
       // создаем новое неизвестное изменение

--- a/VKUI/auto-update-release-notes/src/parsing/parseChanges.ts
+++ b/VKUI/auto-update-release-notes/src/parsing/parseChanges.ts
@@ -8,10 +8,13 @@ const CODE_BLOCK_START_REGEX = /```(diff)?/;
 const CODE_BLOCK_END_REGEX = /```/;
 
 function removeLeadingSpaces(str: string, n: number): string {
-  // Создаем регулярное выражение для проверки n пробелов в начале строки
-  const regexStr = `^\\s{${n}}`;
-  const regex = new RegExp(regexStr);
-  return regex.test(str) ? str.slice(n) : str;
+  const spaceRegex = /^(\s+)/;
+  const match = str.match(spaceRegex);
+  if (!match || !match[1]) {
+    return str;
+  }
+  const leadingSpacesCount = match[1].length;
+  return str.slice(Math.min(leadingSpacesCount, n));
 }
 
 export function parseChanges(text: string): ChangeData[] {
@@ -30,7 +33,7 @@ export function parseChanges(text: string): ChangeData[] {
     const codeBlockEndMatch: RegExpMatchArray | null = codeBlockStarted
       ? line.match(CODE_BLOCK_END_REGEX)
       : null;
-
+    // '  Большой заголовок'
     const addToAdditionalInfo = () => {
       if (currentChange) {
         const subInfo = currentChange.type === 'component' && currentChange.subInfo;

--- a/VKUI/auto-update-release-notes/src/types.ts
+++ b/VKUI/auto-update-release-notes/src/types.ts
@@ -8,6 +8,7 @@ export type SectionType =
 
 type ComponentChangeData = {
   type: 'component';
+  subInfo: boolean;
   component: string;
   description: string;
   pullRequestNumber?: number;

--- a/VKUI/auto-update-release-notes/src/updateReleaseNotes.test.ts
+++ b/VKUI/auto-update-release-notes/src/updateReleaseNotes.test.ts
@@ -652,4 +652,143 @@ describe('run updateReleaseNotes', () => {
 `,
     });
   });
+
+  it('should correct add changes with code diff', async () => {
+    const mockedData = setupData();
+
+    mockedData.releaseData = {
+      draft: true,
+      id: 123,
+      name: 'v6.5.0',
+      body: `
+## Новые компоненты
+- Новый компонент с название COMPONENT
+
+## Улучшения
+- [ChipsSelect](https://vkcom.github.io/VKUI/6.3.0/#/ChipsSelect): Улучшение компонента ChipsSelect (#7023)
+
+## Исправления
+- [List](https://vkcom.github.io/VKUI/6.3.0/#/List): Исправление компонента List (#7094)
+
+## Зависимости
+- Обновлена какая-то зависимость 1
+
+## Документация
+- CustomScrollView: Обновлена документация CustomScrollView`,
+    };
+
+    mockedData.pullRequestData = {
+      body: `
+## Описание
+Какое-то описание Pull Request
+
+## Изменения
+Какие-то изменения Pull Request
+
+## Release notes
+## BREAKING CHANGE
+
+- Header: изменен формат \`size\`  с \`'regular' | 'large'\` на \`'m' | 'l'\`
+  \`\`\`diff
+  - <Header mode="primary" size="large">
+  + <Header mode="primary" size="l">
+    Большой заголовок
+  </Header>
+  \`\`\`
+- Проверка более сложного примера кода
+  \`\`\`diff
+  - <Header mode="primary" size="large">
+  + <Header mode="primary" size="l">
+    <div>
+      <div>
+        Большой заголовок
+      </div>
+    </div>
+  </Header>
+  \`\`\`
+- Spinner: изменен формат \`size\`  с \`'small' | 'regular' | 'medium' | 'large'\` на \`'s' | 'm' | 'l' | 'xl'\`
+  \`\`\`diff
+  - <Spinner size="large" />
+  + <Spinner size="xl" />
+  - <Spinner size="medium" />
+  + <Spinner size="l" />
+  - <Spinner size="regular" />
+  + <Spinner size="m" />
+  - <Spinner size="small" />
+  + <Spinner size="s" />
+  \`\`\`
+`,
+      user: {
+        login: 'eldar',
+      },
+      fork: false,
+    };
+
+    mockedData.lastReleaseName = 'v6.4.0';
+
+    await updateReleaseNotes({
+      octokit: mockedData.octokit,
+      owner: 'owner',
+      repo: 'repo',
+      prNumber: 1234,
+    });
+    expect(mockedData.createReleaseRequest).toHaveBeenCalledTimes(0);
+    expect(mockedData.getReleaseRequest).toHaveBeenCalledWith({
+      owner: 'owner',
+      repo: 'repo',
+      per_page: 10,
+    });
+
+    expect(mockedData.updateReleaseRequest).toHaveBeenCalledWith({
+      owner: 'owner',
+      repo: 'repo',
+      release_id: 123,
+      body: `
+## Новые компоненты
+- Новый компонент с название COMPONENT
+
+## Улучшения
+- [ChipsSelect](https://vkcom.github.io/VKUI/6.3.0/#/ChipsSelect): Улучшение компонента ChipsSelect (#7023)
+
+## Исправления
+- [List](https://vkcom.github.io/VKUI/6.3.0/#/List): Исправление компонента List (#7094)
+
+## Зависимости
+- Обновлена какая-то зависимость 1
+
+## Документация
+- CustomScrollView: Обновлена документация CustomScrollView\r
+## BREAKING CHANGE\r
+- [Header](https://vkcom.github.io/VKUI/6.5.0/#/Header): изменен формат \`size\`  с \`'regular' | 'large'\` на \`'m' | 'l'\` (#1234)\r
+  \`\`\`diff\r
+  - <Header mode="primary" size="large">\r
+  + <Header mode="primary" size="l">\r
+    Большой заголовок\r
+  </Header>\r
+  \`\`\`\r
+- Проверка более сложного примера кода (#1234)\r
+  \`\`\`diff\r
+  - <Header mode="primary" size="large">\r
+  + <Header mode="primary" size="l">\r
+    <div>\r
+      <div>\r
+        Большой заголовок\r
+      </div>\r
+    </div>\r
+  </Header>\r
+  \`\`\`\r
+- [Spinner](https://vkcom.github.io/VKUI/6.5.0/#/Spinner): изменен формат \`size\`  с \`'small' | 'regular' | 'medium' | 'large'\` на \`'s' | 'm' | 'l' | 'xl'\` (#1234)\r
+  \`\`\`diff\r
+  - <Spinner size="large" />\r
+  + <Spinner size="xl" />\r
+  - <Spinner size="medium" />\r
+  + <Spinner size="l" />\r
+  - <Spinner size="regular" />\r
+  + <Spinner size="m" />\r
+  - <Spinner size="small" />\r
+  + <Spinner size="s" />\r
+  \`\`\`\r
+`,
+    });
+  });
 });


### PR DESCRIPTION
## Описание

Сейчас скрипт по автообновлению release notes не поддерживает код в описании изменения. Конкретно кейс:
- Button: какие то изменения
  ```diff
  - Код до изменений
  + Код после изменений
  ```
В этом кейсе скрипт может воспринять строку `- Код до изменений` как отдельное изменение из-за того, что в начале идет "-"

## Изменения

Доработал скрипт автообновления, так чтобы блоки кода обрабатывались отдельно при этом сохраняя все внутреннее форматирование для удобства пользования
