### PR TITLE
fix: fix path to script

### DIFF
--- a/VKUI/add-next-minor-milestone/action.yml
+++ b/VKUI/add-next-minor-milestone/action.yml
@@ -10,4 +10,4 @@ inputs:
     description: 'pull request number to add milestone'
 runs:
   using: 'node20'
-  main: 'index.js'
+  main: 'dist/index.js'


### PR DESCRIPTION
## Описание
 
Из-за того, что в скрипте add-next-minor-milestone в action.yml быд неправильно указан путь до скрипта, он падал на ci/cd при создании пул реквеста

## Изменения

Поправил путь до скрипта add-next-minor-milestone 