### PR TITLE
fix: fix parsing changes with subitems

### DIFF
--- a/VKUI/auto-update-release-notes/src/parsing/parseChanges.ts
+++ b/VKUI/auto-update-release-notes/src/parsing/parseChanges.ts
@@ -50,12 +50,12 @@ export function parseChanges(text: string): ChangeData[] {
       const match = componentMatch || componentWithLinkMatch;
       if (match) {
         const component = match[1];
-        const description = match[2].trim();
+        const description = match[2] || '';
         currentChange = {
           type: 'component',
           subInfo: false,
           component: component,
-          description: description,
+          description: description.trim(),
           additionalInfo: '',
         };
         changes.push(currentChange);


### PR DESCRIPTION
## Описание

Сейчас скрипт авто обновления релиз ноутов падает при парсинге изменений типа:
```
- Компонент:
  - Изменение 1
  - Изменение 2
```
Ошибка в том, что при проходе регуляркой по строке ожидается, что компонент имеет описание, но так не всегда. Нужно добавить проверку
