### PR TITLE
fix: fix bugs and improve code

### DIFF
--- a/VKUI/auto-update-release-notes/src/calculateReleaseVersion.ts
+++ b/VKUI/auto-update-release-notes/src/calculateReleaseVersion.ts
@@ -7,7 +7,7 @@ type ReleaseData = {
 };
 
 const parseReleaseVersion = (releaseVersion: string): string | null => {
-  const match = releaseVersion.match(/v(\d+\.\d+\.\d+)/);
+  const match = releaseVersion.match(/v(\d+\.\d+\.\d+(-beta\.\d+)?)/);
   return match?.[1] || null;
 };
 

--- a/VKUI/auto-update-release-notes/src/parsing/parseChanges.ts
+++ b/VKUI/auto-update-release-notes/src/parsing/parseChanges.ts
@@ -33,7 +33,6 @@ export function parseChanges(text: string): ChangeData[] {
     const codeBlockEndMatch: RegExpMatchArray | null = codeBlockStarted
       ? line.match(CODE_BLOCK_END_REGEX)
       : null;
-    // '  Большой заголовок'
     const addToAdditionalInfo = () => {
       if (currentChange) {
         const subInfo = currentChange.type === 'component' && currentChange.subInfo;

--- a/VKUI/auto-update-release-notes/src/parsing/releaseNotesUpdater.ts
+++ b/VKUI/auto-update-release-notes/src/parsing/releaseNotesUpdater.ts
@@ -18,8 +18,9 @@ export function releaseNotesUpdater(currentBody: string) {
     const matches = body.matchAll(sectionRegex);
     for (const match of matches) {
       const [, header, content] = match;
+      const trimmedHeader = header.trim();
       const trimmedContent = content.trim();
-      const typeByHeader = getSectionTypeByHeader(header);
+      const typeByHeader = getSectionTypeByHeader(trimmedHeader);
       if (!typeByHeader) {
         continue;
       }
@@ -44,6 +45,11 @@ export function releaseNotesUpdater(currentBody: string) {
     body = body.slice(0, startIndex) + '\r\n' + currentContent + '\r\n' + body.slice(endIndex);
   };
 
+  const addSectionWithContent = (header: string, content: string) => {
+    body += `\r\n## ${header}\r\n`;
+    body += content;
+  };
+
   const addNotes = ({
     noteData,
     version,
@@ -65,20 +71,22 @@ export function releaseNotesUpdater(currentBody: string) {
         return convertChangesToString(currentSectionContentData, version, author || '');
       });
     } else {
-      body += `\r\n## ${getHeaderBySectionType(noteData.type)}\r\n`;
-      body += convertChangesToString(noteData.data, version, author || '');
+      addSectionWithContent(
+        headerByType,
+        convertChangesToString(noteData.data, version, author || ''),
+      );
     }
   };
 
   const addUndescribedPRNumber = (prNumber: number) => {
-    if (body.includes(NEED_TO_DESCRIBE_HEADER)) {
+    const header = `## ${NEED_TO_DESCRIBE_HEADER}`;
+    if (body.includes(header)) {
       insertContentInSection(NEED_TO_DESCRIBE_HEADER, (currentContent) => {
         currentContent += `\r\n#${prNumber}`;
         return currentContent;
       });
     } else {
-      body += `\r\n## ${NEED_TO_DESCRIBE_HEADER}\r\n`;
-      body += `#${prNumber}`;
+      addSectionWithContent(NEED_TO_DESCRIBE_HEADER, `#${prNumber}`);
     }
   };
 

--- a/VKUI/auto-update-release-notes/src/updateReleaseNotes.test.ts
+++ b/VKUI/auto-update-release-notes/src/updateReleaseNotes.test.ts
@@ -653,24 +653,24 @@ describe('run updateReleaseNotes', () => {
 - Новый компонент с название COMPONENT3 (#1234, спасибо @other)\r
 \r
 ## Улучшения\r
-- [ChipsSelect](https://vkcom.github.io/VKUI/6.6.0/#/ChipsSelect):\r
+- [ChipsSelect](https://vkcom.github.io/VKUI/6.6.0-beta.0/#/ChipsSelect):\r
   - Улучшение компонента ChipsSelect (#7023)\r
   - Улучшение компонента ChipsSelect 2 (#1234, спасибо @other)\r
     Немного подробнее об этом. Можно приложить картинку\r
-- [ChipsInput](https://vkcom.github.io/VKUI/6.6.0/#/ChipsInput): Улучшение компонента ChipsInput (#1234, спасибо @other)\r
+- [ChipsInput](https://vkcom.github.io/VKUI/6.6.0-beta.0/#/ChipsInput): Улучшение компонента ChipsInput (#1234, спасибо @other)\r
 \r
 ## Исправления\r
-- [List](https://vkcom.github.io/VKUI/6.6.0/#/List):\r
+- [List](https://vkcom.github.io/VKUI/6.6.0-beta.0/#/List):\r
   - Исправление компонента List (#7094)\r
   - Исправление компонента List 2 (#1234, спасибо @other)\r
-- [Flex](https://vkcom.github.io/VKUI/6.6.0/#/Flex): Исправление компонента Flex (#1234, спасибо @other)\r
+- [Flex](https://vkcom.github.io/VKUI/6.6.0-beta.0/#/Flex): Исправление компонента Flex (#1234, спасибо @other)\r
 \r
 ## Зависимости\r
 - Обновлена какая-то зависимость 1\r
 - Обновлена какая-то зависимость 2 (#1234, спасибо @other)\r
 \r
 ## Документация\r
-- [CustomScrollView](https://vkcom.github.io/VKUI/6.6.0/#/CustomScrollView): Обновлена документация CustomScrollView\r
+- [CustomScrollView](https://vkcom.github.io/VKUI/6.6.0-beta.0/#/CustomScrollView): Обновлена документация CustomScrollView\r
 - Поправлены баги в документации (#1234, спасибо @other)\r
 \r
 `,


### PR DESCRIPTION
## Изменения

В скрипте автообновления релиз ноутов поправил две проблемы:
1. Неправильный расчет ссылки на компонент, если версия релиза с суфиксом -beta.{n}. Поправил парсинг и добавил тест
2. Если в пул реквесте после заголовка раздела(Улучшения, Исправления и тд) поставить пробел, то раздел не парсился, так как искалось совпадение со строкой без пробелов. Поправил проверку, добавил trim, чтобы получить строку без пробелов вокруг