### PR TITLE
fix(nvmrc-up-pr): rm sort by date

### DIFF
--- a/shared/node/nvmrc-up-pr/action.yml
+++ b/shared/node/nvmrc-up-pr/action.yml
@@ -9,7 +9,7 @@ runs:
   using: "composite"
   steps:
     - name: Run update version
-      run: curl -s https://nodejs.org/dist/index.json | jq 'map(select(.lts != false))|sort_by(.date)[-1].version' -r > .nvmrc
+      run: curl -s https://nodejs.org/dist/index.json | jq 'map(select(.lts != false))[0].version' -r > .nvmrc
       shell: bash
 
     - name: Create Pull Request


### PR DESCRIPTION
Убираем сортировку по дате, так как могут быть выпущены патчи для старых версий. При этом файл уже отсортирован по версиям