### PR TITLE
fix: update patch label title

### DIFF
--- a/VKUI/auto-update-release-notes/src/calculateReleaseVersion.ts
+++ b/VKUI/auto-update-release-notes/src/calculateReleaseVersion.ts
@@ -46,7 +46,7 @@ export async function calculateReleaseVersion({
     return null;
   }
 
-  const hasPatchLabel = labels.some((label) => label.name === 'patch');
+  const hasPatchLabel = labels.some((label) => label.name === 'ci:cherry-pick:patch');
   const updateType = hasPatchLabel ? 'patch' : 'minor';
   const nextVersion = getNextReleaseVersion(latestVersion, updateType);
 

--- a/VKUI/auto-update-release-notes/src/updateReleaseNotes.test.ts
+++ b/VKUI/auto-update-release-notes/src/updateReleaseNotes.test.ts
@@ -459,7 +459,7 @@ describe('run updateReleaseNotes', () => {
       },
       labels: [
         {
-          name: 'patch',
+          name: 'ci:cherry-pick:patch',
         },
       ],
     };


### PR DESCRIPTION
## Описание

label  `patch` был переименован в `ci:cherry-pick:patch` . Нужно поправить проверку, чтобы скрипт работал корректно