### PR TITLE
fix: fix release name

### DIFF
--- a/icons/auto-update-release-notes/src/getReleaseDraft.ts
+++ b/icons/auto-update-release-notes/src/getReleaseDraft.ts
@@ -16,7 +16,7 @@ export async function getReleaseDraft(
 ) {
   const nextMinorVersion = getNextMinorVersion(currentIconsVersion);
 
-  const releaseName = `@vkontakte/icons@v${nextMinorVersion}`;
+  const releaseName = `@vkontakte/icons@${nextMinorVersion}`;
 
   const { data: releases } = await octokit.rest.repos.listReleases({
     owner,


### PR DESCRIPTION
## Описание

Убрал "v" перед версией в названии релиз ноута, чтобы название соответствовало назвнанию тега при релизе