### PR TITLE
fix(corepack-up-pr): disable YARN_ENABLE_IMMUTABLE_INSTALLS

### DIFF
--- a/shared/node/corepack-up-pr/action.yml
+++ b/shared/node/corepack-up-pr/action.yml
@@ -11,6 +11,8 @@ runs:
     - name: Run corepack up
       run: corepack up
       shell: bash
+      env:
+        YARN_ENABLE_IMMUTABLE_INSTALLS: false
 
     - name: Create Pull Request
       uses: peter-evans/create-pull-request@v7


### PR DESCRIPTION
Для corepack up отключаем IMMUTABLE, так как yarn.lock может меняться в новых версиях

https://github.com/VKCOM/VKUI/actions/runs/24650686353/job/72110600719