### PR TITLE
fix: at auto-update-release-notes script fix typography link url

### DIFF
--- a/VKUI/auto-update-release-notes/src/parsing/getComponentDocsUrl.ts
+++ b/VKUI/auto-update-release-notes/src/parsing/getComponentDocsUrl.ts
@@ -14,14 +14,6 @@ const COMPONENTS_DOCS_PARENT_MAP: Record<string, string> = {
   ActionSheetItem: 'ActionSheet',
   HorizontalCellShowMore: 'HorizontalCell',
   OnboardingTooltipContainer: 'OnboardingTooltip',
-  DisplayTitle: 'Typography',
-  Title: 'Typography',
-  Headline: 'Typography',
-  Text: 'Typography',
-  Paragraph: 'Typography',
-  Subhead: 'Typography',
-  Footnote: 'Typography',
-  Caption: 'Typography',
 };
 
 function toKebabCase(componentName: string) {

--- a/VKUI/auto-update-release-notes/src/updateReleaseNotes.test.ts
+++ b/VKUI/auto-update-release-notes/src/updateReleaseNotes.test.ts
@@ -498,8 +498,8 @@ describe('run updateReleaseNotes', () => {
   <source media="(prefers-color-scheme: dark)" srcset="https://github.com/user-attachments/assets/14bb6d5e-2390-4766-8bdb-8e16d5166523">
   <img width="480" src="https://github.com/user-attachments/assets/404e2412-ed5d-4503-bf61-7c41d8784719"/>
   </picture>
-- [Text](https://vkui.io/6.7.0/components/typography#text): добавлено использование compact токенов fontWeight/fontFamily в режиме compact (#7564)
-- [Caption](https://vkui.io/6.7.0/components/typography#caption): добавлена поддержка compact режима (#7555)
+- [Text](https://vkui.io/6.7.0/components/text): добавлено использование compact токенов fontWeight/fontFamily в режиме compact (#7564)
+- [Caption](https://vkui.io/6.7.0/components/caption): добавлена поддержка compact режима (#7555)
 `,
     };
 
@@ -551,8 +551,8 @@ describe('run updateReleaseNotes', () => {
   <source media="(prefers-color-scheme: dark)" srcset="https://github.com/user-attachments/assets/14bb6d5e-2390-4766-8bdb-8e16d5166523">\r
   <img width="480" src="https://github.com/user-attachments/assets/404e2412-ed5d-4503-bf61-7c41d8784719"/>\r
   </picture>\r
-- [Text](https://vkui.io/6.6.0/components/typography#text): Добавлено использование compact токенов fontWeight/fontFamily в режиме compact (#7564)\r
-- [Caption](https://vkui.io/6.6.0/components/typography#caption): Добавлена поддержка compact режима (#7555)\r
+- [Text](https://vkui.io/6.6.0/components/text): Добавлено использование compact токенов fontWeight/fontFamily в режиме compact (#7564)\r
+- [Caption](https://vkui.io/6.6.0/components/caption): Добавлена поддержка compact режима (#7555)\r
 - [ScreenSpinner](https://vkui.io/6.6.0/components/screen-spinner): Добавлена возможность прокидывать \`caption\` (#1234)\r
   <picture>\r
   <source media="(prefers-color-scheme: dark)" srcset="https://github.com/user-attachments/assets/60251995-5276-4d3d-89ae-d4380d5039f4">\r


### PR DESCRIPTION
## Описание

После https://github.com/VKCOM/VKUI/pull/9793 теперь не нужно кастомить ссылку на элементы типографики